### PR TITLE
Added custom decorator to view if user is_admin. If not, it returns "…

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ from flask_jwt_extended import JWTManager
 from models.user import UserModel
 from resources.user import UserRegister, User, UserLogin
 from resources.property import Properties, Property
-
+from functools import wraps
 from db import db
 
 
@@ -32,7 +32,19 @@ def role_loader(identity):
     if user.role == 'admin':
         return{'is_admin': True}
     return {'is_admin': False}
-    
+
+#custom decorator, JWT is present + user has admin permissions
+def user_is_admin(fn):
+	@wraps(fn)
+	def admin_wrapper(*args, **kwargs):
+		verify_jwt_in_request()
+		user_admin_claim=get_jwt_claims()
+		if(user_admin_claim[is_admin]):
+			return fn(*args, **kwargs)
+		else:
+			return {"message":"Action is not Authorized"}, 403
+	return admin_wrapper
+
 
 api.add_resource(UserRegister, '/register')
 api.add_resource(Property,'/properties/<string:name>')

--- a/resources/property.py
+++ b/resources/property.py
@@ -26,6 +26,7 @@ class Properties(Resource):
         return {'properties': [property.json() for property in PropertyModel.query.all()]}
     
     # @jwt_required()
+    #@user_is_admin
     def post(self):
         data = Properties.parser.parse_args()
 
@@ -51,6 +52,7 @@ class Property(Resource):
     parser.add_argument('state')
 
     # @jwt_required()
+    #@user_is_admin
     def get(self, name):
         rentalProperty = PropertyModel.find_by_name(name)
 
@@ -59,6 +61,7 @@ class Property(Resource):
         return {'message': 'Property not found'}, 404
     
     # @jwt_required()
+    #@user_is_admin
     def delete(self, name):
         property = PropertyModel.find_by_name(name)
         if property:
@@ -67,6 +70,7 @@ class Property(Resource):
         return {'message': 'Property not found.'}, 404
 
     # @jwt_required()
+    #@user_is_admin
     def put(self, name):
         data = Properties.parser.parse_args()
         rentalProperty = PropertyModel.find_by_name(name)


### PR DESCRIPTION
…Action is not Authorized" (403) error
In regards to: Implement JWT Claims #88 in dwellingly-app
I created a custom decorator to view if the user is an admin, because I thought it would be better than checking in every endpoint. 

I was also unsure which endpoints would need the admin permission, that is why it is still commented out. 